### PR TITLE
フォントサイズを小さくする

### DIFF
--- a/Assets/Fonts/MPLUSRounded1c-Regular.asset
+++ b/Assets/Fonts/MPLUSRounded1c-Regular.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:599ddffdf2e25e55889e898118eea9a7cdebc588943f2434e02e345d6fb002b2
-size 136874624
+oid sha256:c3b2f93e9a9202de4e5a8c5cf4bb7b5965ba077931b1bcc5da64f0eb6be269bc
+size 36242926

--- a/Assets/Fonts/NotoSansJP-Regular.asset
+++ b/Assets/Fonts/NotoSansJP-Regular.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd4fe0273c588b1a740605e64e00ab2dd9128c7372099cd5e3eb214ebfea29c1
-size 137525601
+oid sha256:fb9bc5285ea0134f28df940988818d6b177101fcf189f285864fce25bb6945fa
+size 36851525

--- a/Assets/Fonts/NotoSansJP-Regular.asset.meta
+++ b/Assets/Fonts/NotoSansJP-Regular.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b3c7c4f06cb6c46bd95f6061fd619f66
+guid: fb724f55c9de1451c8ea59f7767d64d6
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000


### PR DESCRIPTION
アトラスの大きさを8192×8192→4096×4096に変更
136MB→36MBくらいまで減った